### PR TITLE
fix setsockoopt() invalid argument size

### DIFF
--- a/src/redispp.cpp
+++ b/src/redispp.cpp
@@ -15,7 +15,7 @@ int close(SOCKET sock)
 static bool setSocketFlag(SOCKET sock, int level, int optname, bool value)
 {
     BOOL val = value ? TRUE : FALSE;
-    return 0 == setsockopt(sock, level, optname, (char*)&val, sizeof(value));
+    return 0 == setsockopt(sock, level, optname, (char*)&val, sizeof(val));
 }
 
 static const char* getLastErrorMessage()
@@ -36,7 +36,7 @@ typedef void* RecvBufferType;
 static bool setSocketFlag(SOCKET sock, int level, int optname, bool value)
 {
     int val = value ? 1 : 0;
-    return 0 == setsockopt(sock, level, optname, &val, sizeof(value));
+    return 0 == setsockopt(sock, level, optname, &val, sizeof(val));
 }
 
 static const char* getLastErrorMessage()


### PR DESCRIPTION
before patch:
setsockopt(3, SOL_SOCKET, SO_REUSEADDR, "\1", 1) = -1 EINVAL (Invalid argument)
setsockopt(3, SOL_SOCKET, SO_KEEPALIVE, "\1", 1) = -1 EINVAL (Invalid argument)
setsockopt(3, SOL_TCP, TCP_NODELAY, "\1", 1) = -1 EINVAL (Invalid argument)

after patch:
setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
setsockopt(3, SOL_SOCKET, SO_KEEPALIVE, [1], 4) = 0
setsockopt(3, SOL_TCP, TCP_NODELAY, [1], 4) = 0

tested on linux 3.10.25 x86_64
