### PR TITLE
Fix memory leak

### DIFF
--- a/src/redispp.cpp
+++ b/src/redispp.cpp
@@ -264,6 +264,11 @@ public:
     Buffer(size_t bufferSize)
     : buffer(new char[bufferSize]), spot(buffer), end(buffer + bufferSize), marked(buffer)
     {}
+    
+    ~Buffer()
+    {
+    	delete[] buffer;
+    }
 
     void write(char c)
     {


### PR DESCRIPTION
The char array for 'buffer' is not deallocated whenever a Buffer object is destroyed.  This commit addresses the issue.