### PR TITLE
Travis links still point to my forked repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Another C++ client for Redis [![Build Status](https://img.shields.io/travis/kevinkjt2000/redispp/master.svg?style=flat-square&label=Travis)](https://travis-ci.org/kevinkjt2000/redispp)
+# Another C++ client for Redis [![Build Status](https://img.shields.io/travis/brianwatling/redispp/master.svg?style=flat-square&label=Travis)](https://travis-ci.org/brianwatling/redispp)
 
 - Supports pipelining, using the same functions as synchronous requests
 - The included performance test runs about 5 times faster with pipelining than with synchronous requests (single client/thread, on my laptop, to localhost)


### PR DESCRIPTION
I believe all you have to do to fix this is sign-in to https://travis-ci.org by using their sign-in with GitHub button, adjust the slider for redispp to be "on" in your travis profile, and then this pull request will point the badge towards the correct builds.

![image](https://cloud.githubusercontent.com/assets/4098674/26792984/e1f5dc46-49e1-11e7-9c91-e425c88ef3ae.png)